### PR TITLE
Fix data conversion of records 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,13 +1225,8 @@ without overhead. The same is true for arrow types. The fields in Miking records
 are un-ordered while they are ordered in OCaml so there is some overhead
 involved when converting records as each field of the Miking records needs to be
 projected to form an new OCaml records, and vice versa. The fields of the Miking
-record are associated with the fields of the OCaml record syntactically by
-position when defining the external. As an example, if the external
-```
-external myRecord : {a : Int, b: Float}
-```
-has an OCaml implementation with type `{c : int; d : float}` then the field `a` is
-associated with the field `c` and the field `b` with the field `d`.
+record are associated with the fields of the OCaml record by an explicit mapping
+defined in the `*.ext-ocaml.mc` file.
 
 If the Miking type is abstract, i.e. we define it as 
 ```

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -7,6 +7,35 @@ let implWithLibs = lam arg : { expr : String, ty : Type, libraries : [String] }.
 let impl = lam arg : { expr : String, ty : Type }.
   implWithLibs { expr = arg.expr, ty = arg.ty, libraries = [] }
 
+let myrecty1 = otyrecordext_
+  (otyvarext_ "Boot.Exttest.myrec1_t" [])
+  [
+    { label = "a", asLabel = "c", ty = tyint_ },
+    { label = "b", asLabel = "d", ty = tyfloat_ }
+  ]
+
+let myrecty2 = otyrecordext_
+  (otyvarext_ "Boot.Exttest.myrec2_t" [])
+  [
+    { label = "a", asLabel = "c", ty = otylist_ tyint_ },
+    { label = "b", asLabel = "d", ty = tyint_ }
+  ]
+
+let myrecty3 = otyrecordext_
+  (otyvarext_ "Boot.Exttest.myrec3_t" [])
+  [
+    {
+      label = "a",
+      asLabel = "c",
+      ty = myrecty1
+    },
+    {
+      label = "b",
+      asLabel = "d",
+      ty = myrecty2
+    }
+  ]
+
 let extTestMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
@@ -98,77 +127,42 @@ let extTestMap =
       impl
       {
         expr = "Boot.Exttest.myrec1",
-        ty = otyrecord_
-              (otyvarext_ "Boot.Exttest.myrec1_t" [])
-              [("a", tyint_), ("b", tyfloat_)]
+        ty = myrecty1
       }
     ]),
     ("extTestRecord1A", [
       impl
       {
         expr = "Boot.Exttest.myrec1_a",
-        ty = tyarrow_ (otyrecord_
-                        (otyvarext_ "Boot.Exttest.myrec1_t" [])
-                        [("a", tyint_), ("b", tyfloat_)])
-                      tyint_
+        ty = tyarrow_ myrecty1 tyint_
       }
     ]),
     ("extTestRecord2", [
       impl
       {
         expr = "Boot.Exttest.myrec2",
-        ty = otyrecord_
-              (otyvarext_ "Boot.Exttest.myrec2_t" [])
-              [("a", otylist_ tyint_), ("b", tyint_)]
+        ty = myrecty2
       }
     ]),
     ("extTestRecord2A", [
       impl
       {
         expr = "Boot.Exttest.myrec2_a",
-        ty = tyarrow_ (otyrecord_
-                        (otyvarext_ "Boot.Exttest.myrec2_t" [])
-                        [("a", otylist_ tyint_), ("b", tyint_)])
-                      (otylist_ tyint_)
+        ty = tyarrow_ myrecty2 (otylist_ tyint_)
       }
     ]),
     ("extTestRecord3", [
       impl
       {
         expr = "Boot.Exttest.myrec3",
-        ty = otyrecord_
-              (otyvarext_ "Boot.Exttest.myrec3_t" [])
-              [
-                ("a"
-                ,otyrecord_
-                  (otyvarext_ "Boot.Exttest.myrec1_t" [])
-                  [("a", tyint_), ("b", tyfloat_)]),
-                ("b"
-                ,otyrecord_
-                  (otyvarext_ "Boot.Exttest.myrec2_t" [])
-                  [("a", otylist_ tyint_), ("b", tyint_)])
-              ]
+        ty = myrecty3
       }
     ]),
     ("extTestRecord3BA", [
       impl
       {
         expr = "Boot.Exttest.myrec3_b_a",
-        ty =
-          tyarrow_
-            (otyrecord_
-              (otyvarext_ "Boot.Exttest.myrec3_t" [])
-              [
-                ("a"
-                ,otyrecord_
-                  (otyvarext_ "Boot.Exttest.myrec1_t" [])
-                  [("a", tyint_), ("b", tyfloat_)]),
-                ("b"
-                ,otyrecord_
-                  (otyvarext_ "Boot.Exttest.myrec2_t" [])
-                  [("a", otylist_ tyint_), ("b", tyint_)])
-              ])
-            (otylist_ tyint_)
+        ty = tyarrow_ myrecty3 (otylist_ tyint_)
       }
     ]),
     ("extTestArgLabel", [

--- a/stdlib/ext/ext-test.mc
+++ b/stdlib/ext/ext-test.mc
@@ -10,16 +10,16 @@ mexpr
 external extTestListOfLists : [[Int]] in
 utest extTestListOfLists with [[0]] in
 
-external extTestListHeadHead : [[a]] -> a in
+external extTestListHeadHead : all a. [[a]] -> a in
 utest extTestListHeadHead [[0]] with 0 in
 
 external extTestArrayOfArrays : [[Int]] in
 utest extTestArrayOfArrays with [[0]] in
 
-external extTestArrayHeadHead : [[a]] -> a in
+external extTestArrayHeadHead : all a. [[a]] -> a in
 utest extTestArrayHeadHead [[0]] with 0 in
 
-external extTestFlip : (a -> b -> c) -> b -> a -> c in
+external extTestFlip : all a. all b. all c. (a -> b -> c) -> b -> a -> c in
 utest extTestFlip (lam x. lam y. subi x y) 1 2 with 1 in
 
 external extTestUnit1 : Int -> () in

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -27,7 +27,8 @@ lang OCamlRecord
   syn Pat =
   | OPatRecord {bindings : Map SID Pat}
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmRecord t ->
     let bindFunc = lam acc. lam bind : (String, Expr).
@@ -42,7 +43,8 @@ lang OCamlRecord
       (acc, OTmProject {t with tm = tm})
     else never
 
-  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat
+    : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
   sem smapAccumL_Pat_Pat f acc =
   | OPatRecord t ->
     match mapMapAccum (lam acc. lam. lam p. f acc p) acc t.bindings
@@ -60,7 +62,8 @@ lang OCamlMatch
 
   syn Pat =
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmMatch t ->
     let armsFunc = lam acc. lam arm : (Pat, Expr).
@@ -79,7 +82,8 @@ lang OCamlArray
   syn Expr =
   | OTmArray {tms : [Expr]}
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmArray t ->
     match mapAccumL f acc t.tms with (acc, tms) then
@@ -94,14 +98,16 @@ lang OCamlTuple
   syn Pat =
   | OPatTuple { pats : [Pat] }
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmTuple t ->
     match mapAccumL f acc t.values with (acc, values) then
       (acc, OTmTuple {t with values = values})
     else never
 
-  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat
+    : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
   sem smapAccumL_Pat_Pat f acc =
   | OPatTuple t ->
     match mapAccumL f acc t.pats with (acc, pats) then
@@ -116,14 +122,16 @@ lang OCamlData
   syn Pat =
   | OPatCon { ident : Name, args : [Pat] }
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmConApp t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OTmConApp {t with args = args})
     else never
 
-  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat
+    : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
   sem smapAccumL_Pat_Pat f acc =
   | OPatCon t ->
     match mapAccumL f acc t.args with (acc, args) then
@@ -153,14 +161,16 @@ lang OCamlExternal
   syn Pat =
   | OPatConExt { ident : String, args : [Pat] }
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmConAppExt t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OTmConAppExt {t with args = args})
     else never
 
-  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat
+    : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
   sem smapAccumL_Pat_Pat f acc =
   | OPatConExt t ->
     match mapAccumL f acc t.args with (acc, args) then
@@ -172,7 +182,8 @@ lang OCamlLabel
   syn Expr =
   | OTmLabel { label : String, arg : Expr }
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmLabel t ->
     match f acc t.arg with (acc, arg) then
@@ -184,7 +195,8 @@ lang OCamlLam
   syn Expr =
   | OTmLam {label : Option String, ident : Name, body : Expr}
 
-  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr
+    : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | OTmLam t ->
     match f acc t.body with (acc, body) then
@@ -235,7 +247,8 @@ lang OCamlTypeAst =
   | OTyRecordExt r -> r.info
   | OTyString r -> r.info
 
-  sem smapAccumL_Type_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
+  sem smapAccumL_Type_Type
+    : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
   sem smapAccumL_Type_Type f acc =
   | OTyList t ->
     match f acc t.ty with (acc, ty) in
@@ -276,9 +289,10 @@ lang OCamlTypeAst =
     (acc, OTyRecord {{t with fields = fields}
                         with tyident = tyident})
   | OTyRecordExt t ->
-    let fieldFun = lam acc. lam field : {label : String, asLabel : String, ty : Type}.
-      match f acc field.ty with (acc, ty) in
-      (acc, { field with ty = ty })
+    let fieldFun =
+      lam acc. lam field : {label : String, asLabel : String, ty : Type}.
+        match f acc field.ty with (acc, ty) in
+        (acc, { field with ty = ty })
     in
     match mapAccumL fieldFun acc t.fields with (acc, fields) in
     match f acc t.tyident with (acc, tyident) in

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -49,13 +49,17 @@ lang OCamlDataConversionBase = OCamlDataConversion + OCamlAst
 end
 
 lang OCamlDataConversionOpaque = OCamlDataConversion + OCamlAst
-  + ConTypeAst + AppTypeAst + UnknownTypeAst
+  + ConTypeAst + AppTypeAst + UnknownTypeAst + AllTypeAst + VarTypeAst
 
   sem convertDataInner info env t =
-  | (TyUnknown _, _) | (_, TyUnknown _)
-  | (TyCon {ident = ident}, _) | (_, TyCon {ident = ident})
-  | (TyApp {lhs = TyCon _}, _) | (_, TyApp {lhs = TyCon _})
+  | (TyUnknown _ | TyVar _, !(TyAll _)) | (!(TyAll _), TyUnknown _ | TyVar _)
+  | (TyCon {ident = ident}, !(TyAll _)) | (!(TyAll _), TyCon {ident = ident})
+  | (TyApp {lhs = TyCon _}, !(TyAll _)) | (!(TyAll _), TyApp {lhs = TyCon _})
   -> (0, t)
+  | (TyAll {ty = ty1}, TyAll {ty = ty2})
+  | (TyAll {ty = ty1}, ty2)
+  | (ty1, TyAll {ty = ty2})
+  -> convertData info env t (ty1, ty2)
 end
 
 lang OCamlDataConversionFun =

--- a/stdlib/pmexpr/replace-accelerate.mc
+++ b/stdlib/pmexpr/replace-accelerate.mc
@@ -21,7 +21,7 @@ lang PMExprReplaceAccelerate =
     let elemType =
       match ty with TyInt _ then OTyBigarrayIntElt {info = info}
       else OTyBigarrayFloat64Elt {info = info} in
-    OTyBigarrayGenarray {info = info, tys = [ty, elemType, layout]}
+    OTyBigarrayGenarray {info = info, ty = ty, elty = elemType, layout = layout}
   | TyTensor t ->
     infoErrorExit t.info "Cannot convert tensor of unsupported type"
 

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -6,23 +6,25 @@ let impl = lam arg : { expr : String, ty : Type }.
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []
 let tyidatriple = otyvarext_ "Ida.triple"
-let tyidajacobianargra =
+let tyidajacobianarg =
   otyvarext_ "Ida.jacobian_arg" [tyidatriple [tyrealarray], tyrealarray]
 
 let tyidajacf =
   tyarrows_ [
-    otyrecord_
-      tyidajacobianargra
+    otyrecordext_
+      tyidajacobianarg
       [
-        ("jac_t", tyfloat_),
-        ("jac_y", otybaarrayclayoutfloat_ 1),
-        ("jac_y'", otybaarrayclayoutfloat_ 1),
-        ("jac_res", otybaarrayclayoutfloat_ 1),
-        ("jac_coef", tyfloat_),
-        ("jac_tmp", otytuple_
-                      [otybaarrayclayoutfloat_ 1,
-                       otybaarrayclayoutfloat_ 1,
-                       otybaarrayclayoutfloat_ 1])
+        { label = "jac_t", asLabel = "t", ty = tyfloat_ },
+        { label = "jac_y", asLabel = "y", ty = otybaarrayclayoutfloat_ 1 },
+        { label = "jac_y'", asLabel = "yp", ty = otybaarrayclayoutfloat_ 1 },
+        { label = "jac_res", asLabel = "res", ty = otybaarrayclayoutfloat_ 1 },
+        { label = "jac_coef", asLabel = "c", ty = tyfloat_ },
+        { label = "jac_tmp", asLabel = "tmp",
+          ty = otytuple_ [
+            otybaarrayclayoutfloat_ 1,
+            otybaarrayclayoutfloat_ 1,
+            otybaarrayclayoutfloat_ 1
+        ] }
       ],
     otyopaque_,
     otyunit_

--- a/test-files.mk
+++ b/test-files.mk
@@ -34,6 +34,7 @@ typecheck_files += test/mlang/type-alias.mc
 typecheck_files += $(wildcard stdlib/*.mc)
 typecheck_files += $(wildcard stdlib/mexpr/*.mc)
 typecheck_files += $(wildcard stdlib/ocaml/*.mc)
+typecheck_files += stdlib/ext/ext-test.mc
 
 
 # Programs that we currently cannot compile/test. These are programs written


### PR DESCRIPTION
This PR fixes conversion of records in externals. In addition it includes type fixes, support for conversion of `TyAll`, formatting fixes, and a refactoring of genarray conversion.

When declaring an external that maps an MExpr record to an OCaml record you must now give an explicit mapping between field labels in the `*.ext-ocaml.mc` file via the `asLabel` field in the `OTyRecordExt` type.